### PR TITLE
Return None for vaf calculation when total_depth is 0.

### DIFF
--- a/pax_io.py
+++ b/pax_io.py
@@ -35,7 +35,10 @@ class PaxVariant(VariantLike) :
         alt_depth = sum(allelic_depth[1:])
         ref_depth = allelic_depth[0]
         total_depth = int(sample_info['DP'])
-        vaf = float(alt_depth) / float(total_depth)
+        if total_depth == 0 :
+            vaf = None
+        else :
+            vaf = float(alt_depth) / float(total_depth)
         return {'ref_reads':   ref_depth, 
                 'alt_reads':   alt_depth,
                 'total_reads': total_depth,
@@ -47,7 +50,10 @@ class PaxVariant(VariantLike) :
         alt_depth = tir_list[0]
         ref_depth = tar_list[0]
         total_depth = ref_depth + alt_depth
-        vaf = float(alt_depth) / float(total_depth)
+        if total_depth == 0 :
+            vaf = None
+        else :
+            vaf = float(alt_depth) / float(total_depth)
         return {'ref_reads':   ref_depth, 
                 'alt_reads':   alt_depth,
                 'total_reads': total_depth,


### PR DESCRIPTION
# 概要
polymer_length_filter.py を実行したとき、`_calc_mutect2_vaf` でvaf を計算する際に、分母(total_depth)が0であるためゼロ除算例外で異常終了する現象が見られた。
これを回避するため、total_depth が0 の場合にはNone を返すよう変更し、また同様の変更を`_calc_strelka2_vaf` にも適用した。
腫瘍で変異のあった検体を対象としているため、腫瘍のtotal_depth が0であればデータかアルゴリズムに問題があるかと思われたが、変更後のスクリプトで計算を行った結果、total_depth が0となるのは正常検体だけだった。
体細胞変異検出の方法を考えると、正常検体の深度が0なのも問題がないわけではないが、重大な問題ではないと考え詳細を調査することはしなかった。

## 実際のエラーログ
一例として`/home/ms1go/Project_WGS_GY/data/plfiter/250727/trash1/log/wrapper_polymer_length_vaf_filter.sh.e115267611.1328` を上げる。
```bash
+ /home/ms1go/local/package/plfiter/250727/PolymerLengthFilter//polymer_length_filter.py output//YG-GY-0198-T-01-D/YG-GY-0198-T-01-D.indels.pax.npp.txt output//YG-GY-0198-T-01-D/YG-GY-0198-T-01-D.indels.pax.npp.vaf_polymer_length_filtered.txt /home/kks_th/CaGMeJ/2.0.0/database/GRCh38/Homo_sapiens_assembly38.fasta
Traceback (most recent call last):
  File "/home/ms1go/local/package/plfiter/250727/PolymerLengthFilter//polymer_length_filter.py", line 49, in <module>
    variant.calc_vaf()
  File "/cshare2/ZETTAI_path_WA_slash_home_KARA/home/ms1go/local/package/plfiter/250727/PolymerLengthFilter/pax_io.py", line 65, in calc_vaf
    normal_reads_info = self._calc_mutect2_vaf(normal_info)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cshare2/ZETTAI_path_WA_slash_home_KARA/home/ms1go/local/package/plfiter/250727/PolymerLengthFilter/pax_io.py", line 38, in _calc_mutect2_vaf
    vaf = float(alt_depth) / float(total_depth)
          ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
ZeroDivisionError: float division by zero
```

## 変更の経緯
エラーに気づいた後藤さんが`_calc_mutect2_vaf` に以下の変更を行い、ついで田中が`_calc_strelka2_vaf`にも同様の変更を適用した。

## 0除算の代わりにNone を返す妥当性について
後藤さんは当初`None`, `np.nan`, `0` のどれを返すか悩んでいたようだが、田中は`np.nan` はライブラリ依存であるため却下、0 は0除算されない他の変異と区別がつかないため却下し、`None` を返したほうが良いと考えた。
ただし、R などで処理するときにはNone は文字列として扱われるため、col_types による型指定が必要となるだろう。
本筋とは外れるが、入力データの行数が少ないなどの理由で`readr` 系の関数が型のguessing を誤りエラーになる例は枚挙にいとまがないので、原則Rでread_tsv などする場合はcol_types による型指定はほぼ必須と考えた方が良い。
